### PR TITLE
Add absolute and relative timestamp handling

### DIFF
--- a/demod.c
+++ b/demod.c
@@ -75,7 +75,7 @@ void fsyncCallBack(int cmd, int subcmd, int from_fleet, int from_unit, int to_fl
 
 void mdcCallBack(int numFrames, unsigned char op, unsigned char arg, unsigned short unitID,\
                   unsigned char extra0, unsigned char extra1, unsigned char extra2, \
-                  unsigned char extra3, void *context){
+                  unsigned char extra3, void *context, u_int32_t timestamp){
     char json_buffer[2048];
     snprintf(json_buffer, sizeof(json_buffer), "{\"type\":\"MDC1200\","\
                                         "\"timestamp\":\"%d\","\
@@ -85,7 +85,7 @@ void mdcCallBack(int numFrames, unsigned char op, unsigned char arg, unsigned sh
                                          "\"ex0\":\"%02x\","\
                                          "\"ex1\":\"%02x\","\
                                          "\"ex2\":\"%02x\","\
-                                         "\"ex3\":\"%02x\"}", (int)time(NULL), op, arg, unitID,extra0, \
+                                         "\"ex3\":\"%02x\"}", timestamp, op, arg, unitID,extra0, \
                                          extra1, extra2, extra3);
 
     fprintf(stdout, "%s\n", json_buffer);
@@ -107,6 +107,7 @@ static void read_input(int inputflag) {
     pa_simple *s;
     pa_sample_spec ss;
 
+    u_int32_t buffer_timestamp;
 
     // Fleetsync
     fsync_decoder_t *f_decoder;
@@ -168,8 +169,11 @@ static void read_input(int inputflag) {
                     // Only care about catching -1 for errors, other return values dont really matter here
                     // Decoders will fire the callbacks when a message is decoded
 
+                    buffer_timestamp = time(NULL);
+                    // buffer_timestamp = 123000123000;
+
                     f_result = fsync_decoder_process_samples(f_decoder, buffer, sizeof(buffer));
-                    m_result = mdc_decoder_process_samples(m_decoder, buffer, sizeof(buffer));
+                    m_result = mdc_decoder_process_samples(m_decoder, buffer, sizeof(buffer), buffer_timestamp);
                     if (f_result == -1)
                         {
                         fprintf(stderr,"Fleetsync Decoder Error\n");

--- a/mdc_decode.c
+++ b/mdc_decode.c
@@ -6,7 +6,7 @@
  * Author: Matthew Kaufman (matthew@eeph.com)
  *
  * Copyright (c) 2005, 2010  Matthew Kaufman  All rights reserved.
- * 
+ *
  *  This file is part of Matthew Kaufman's MDC Encoder/Decoder Library
  *
  *  The MDC Encoder/Decoder Library is free software; you can
@@ -109,7 +109,7 @@ static void _gofix(unsigned char *data)
 	int syn;
 	int fixi,fixj;
 	int ec;
-	
+
 	syn = 0;
 	for(i=0; i<7; i++)
 		csr[i] = 0;
@@ -264,7 +264,8 @@ static void _procbits(mdc_decoder_t *decoder, int x)
 								(unsigned char)decoder->extra1,
 								(unsigned char)decoder->extra2,
 								(unsigned char)decoder->extra3,
-								decoder->callback_context);
+								decoder->callback_context,
+								(u_int32_t)decoder->timestamp);
 			decoder->good = 0;
 
 		}
@@ -368,8 +369,11 @@ static void _nlproc(mdc_decoder_t *decoder, int x)
 
 int mdc_decoder_process_samples(mdc_decoder_t *decoder,
                                 mdc_sample_t *samples,
-                                int numSamples)
+                                int numSamples,
+																u_int32_t samples_timestamp)
 {
+	decoder->timestamp = samples_timestamp;
+
 	mdc_int_t i, j;
 	mdc_sample_t sample;
 #ifndef MDC_FIXEDMATH
@@ -449,7 +453,7 @@ int mdc_decoder_process_samples(mdc_decoder_t *decoder,
 				decoder->du[j].nlstep++;
 				if(decoder->du[j].nlstep > 9)
 					decoder->du[j].nlstep = 0;
-				decoder->du[j].nlevel[decoder->du[j].nlstep] = value;	
+				decoder->du[j].nlevel[decoder->du[j].nlstep] = value;
 
 				_nlproc(decoder, j);
 
@@ -462,7 +466,7 @@ int mdc_decoder_process_samples(mdc_decoder_t *decoder,
 #endif
 	}
 
-	
+
 
 	if(decoder->good)
 		return decoder->good;
@@ -470,7 +474,7 @@ int mdc_decoder_process_samples(mdc_decoder_t *decoder,
 	return 0;
 }
 
-int mdc_decoder_get_packet(mdc_decoder_t *decoder, 
+int mdc_decoder_get_packet(mdc_decoder_t *decoder,
                            unsigned char *op,
 			   unsigned char *arg,
 			   unsigned short *unitID)
@@ -495,7 +499,7 @@ int mdc_decoder_get_packet(mdc_decoder_t *decoder,
 	return 0;
 }
 
-int mdc_decoder_get_double_packet(mdc_decoder_t *decoder, 
+int mdc_decoder_get_double_packet(mdc_decoder_t *decoder,
                            unsigned char *op,
 			   unsigned char *arg,
 			   unsigned short *unitID,

--- a/mdc_decode.c
+++ b/mdc_decode.c
@@ -265,7 +265,8 @@ static void _procbits(mdc_decoder_t *decoder, int x)
 								(unsigned char)decoder->extra2,
 								(unsigned char)decoder->extra3,
 								decoder->callback_context,
-								(u_int32_t)decoder->timestamp);
+								(u_int32_t)decoder->timestamp_absolute,
+								(u_int32_t)decoder->timestamp_relative);
 			decoder->good = 0;
 
 		}
@@ -370,9 +371,11 @@ static void _nlproc(mdc_decoder_t *decoder, int x)
 int mdc_decoder_process_samples(mdc_decoder_t *decoder,
                                 mdc_sample_t *samples,
                                 int numSamples,
-																u_int32_t samples_timestamp)
+																u_int32_t samples_timestamp_absolute,
+																u_int32_t samples_timestamp_relative)
 {
-	decoder->timestamp = samples_timestamp;
+	decoder->timestamp_absolute = samples_timestamp_absolute;
+	decoder->timestamp_relative = samples_timestamp_relative;
 
 	mdc_int_t i, j;
 	mdc_sample_t sample;

--- a/mdc_decode.h
+++ b/mdc_decode.h
@@ -5,7 +5,7 @@
  * Author: Matthew Kaufman (matthew@eeph.com)
  *
  * Copyright (c) 2005, 2010  Matthew Kaufman  All rights reserved.
- * 
+ *
  *  This file is part of Matthew Kaufman's MDC Encoder/Decoder Library
  *
  *  The MDC Encoder/Decoder Library is free software; you can
@@ -61,7 +61,8 @@ typedef void (*mdc_decoder_callback_t)(	int frameCount, // 1 or 2 - if 2 then ex
 										unsigned char extra1,
 										unsigned char extra2,
 										unsigned char extra3,
-										void *context);
+										void *context,
+                    u_int32_t timestamp);
 
 typedef struct
 {
@@ -109,8 +110,9 @@ typedef struct {
 	mdc_u8_t extra3;
 	mdc_decoder_callback_t callback;
 	void *callback_context;
+  u_int32_t timestamp;
 } mdc_decoder_t;
-	
+
 
 
 /*
@@ -137,10 +139,11 @@ mdc_decoder_t * mdc_decoder_new(int sampleRate);
           1 if a decoded single packet is available to read (if no callback set)
           2 if a decoded double packet is available to read (if no callback set)
 */
- 
+
 int mdc_decoder_process_samples(mdc_decoder_t *decoder,
                                 mdc_sample_t *samples,
-                                int numSamples);
+                                int numSamples,
+                                u_int32_t samples_timestamp);
 
 
 /*
@@ -155,7 +158,7 @@ int mdc_decoder_process_samples(mdc_decoder_t *decoder,
  returns: -1 if error, 0 otherwise
 */
 
-int mdc_decoder_get_packet(mdc_decoder_t *decoder, 
+int mdc_decoder_get_packet(mdc_decoder_t *decoder,
                            unsigned char *op,
 			   unsigned char *arg,
 			   unsigned short *unitID);
@@ -176,7 +179,7 @@ int mdc_decoder_get_packet(mdc_decoder_t *decoder,
  returns: -1 if error, 0 otherwise
 */
 
-int mdc_decoder_get_double_packet(mdc_decoder_t *decoder, 
+int mdc_decoder_get_double_packet(mdc_decoder_t *decoder,
                            unsigned char *op,
 			   unsigned char *arg,
 			   unsigned short *unitID,

--- a/mdc_decode.h
+++ b/mdc_decode.h
@@ -62,7 +62,8 @@ typedef void (*mdc_decoder_callback_t)(	int frameCount, // 1 or 2 - if 2 then ex
 										unsigned char extra2,
 										unsigned char extra3,
 										void *context,
-                    u_int32_t timestamp);
+                    u_int32_t timestamp_absolute,
+                    u_int32_t timestamp_relative);
 
 typedef struct
 {
@@ -110,7 +111,8 @@ typedef struct {
 	mdc_u8_t extra3;
 	mdc_decoder_callback_t callback;
 	void *callback_context;
-  u_int32_t timestamp;
+  u_int32_t timestamp_absolute;
+  u_int32_t timestamp_relative;
 } mdc_decoder_t;
 
 
@@ -143,7 +145,8 @@ mdc_decoder_t * mdc_decoder_new(int sampleRate);
 int mdc_decoder_process_samples(mdc_decoder_t *decoder,
                                 mdc_sample_t *samples,
                                 int numSamples,
-                                u_int32_t samples_timestamp);
+                                u_int32_t samples_timestamp_absolute,
+                                u_int32_t samples_timestamp_relative);
 
 
 /*


### PR DESCRIPTION
By shuttling timestamps around into sample processing, should we desire in the future, we can now get time resolution down to the sample where the beginning of an ID is recognized.

To maintain backwards compatibility, leave the `timestamp` key alone as `timestamp_absolute` and present a `tiemstamp_relative`.

If we wanted, we could just agree on a single global absolute starting timestamp, pass around only relative timestamps, and determine absolute timestamps as differences. However, this might not be a good idea due to stream instability and dropping, so providing absolute and relative times separately might be worth the negligible additional data juggling.

